### PR TITLE
PoC `RefMutContainer` V3

### DIFF
--- a/src/bindings/config.rs
+++ b/src/bindings/config.rs
@@ -29,9 +29,7 @@ pub enum Py_Config_Mut<'p> {
 impl From<Py_Config_Mut<'_>> for Config {
     fn from(val: Py_Config_Mut<'_>) -> Self {
         match val {
-            Py_Config_Mut::Owned(x) => {
-                x.inner.to_owned().inner.lock().unwrap().clone()
-            },
+            Py_Config_Mut::Owned(x) => x.inner.to_owned().inner.lock().unwrap().clone(),
             Py_Config_Mut::RefMut(mut x) => {
                 x.inner.map_as_mut(|x| x.clone()).expect(DESTROYED_ERR_MSG)
             }
@@ -42,12 +40,8 @@ impl From<Py_Config_Mut<'_>> for Config {
 impl From<&mut Py_Config_Mut<'_>> for Config {
     fn from(val: &mut Py_Config_Mut<'_>) -> Self {
         match val {
-            Py_Config_Mut::Owned(x) => {
-                x.inner.to_owned().inner.lock().unwrap().clone()
-            },
-            Py_Config_Mut::RefMut(x) => {
-                x.inner.map_as_mut(|x| x.clone()).expect(DESTROYED_ERR_MSG)
-            }
+            Py_Config_Mut::Owned(x) => x.inner.to_owned().inner.lock().unwrap().clone(),
+            Py_Config_Mut::RefMut(x) => x.inner.map_as_mut(|x| x.clone()).expect(DESTROYED_ERR_MSG),
         }
     }
 }

--- a/src/bindings/config.rs
+++ b/src/bindings/config.rs
@@ -2,9 +2,10 @@ use pyo3::{intern, prelude::*};
 
 use raft::Config;
 
+use utils::implement_type_conversion_v3;
 use utils::reference_v3::{RefMutOwner, RustRef};
 
-use utils::errors::{Py_RaftError, DESTROYED_ERR_MSG};
+use utils::errors::{Py_RaftError};
 
 use super::readonly_option::Py_ReadOnlyOption;
 
@@ -26,27 +27,7 @@ pub enum Py_Config_Mut<'p> {
     RefMut(Py_Config_Ref),
 }
 
-impl From<Py_Config_Mut<'_>> for Config {
-    fn from(val: Py_Config_Mut<'_>) -> Self {
-        match val {
-            Py_Config_Mut::Owned(x) => x.inner.to_owned().inner.lock().unwrap().clone(),
-            Py_Config_Mut::RefMut(mut x) => {
-                x.inner.map_as_mut(|x| x.clone()).expect(DESTROYED_ERR_MSG)
-            }
-        }
-    }
-}
-
-impl From<&mut Py_Config_Mut<'_>> for Config {
-    fn from(val: &mut Py_Config_Mut<'_>) -> Self {
-        match val {
-            Py_Config_Mut::Owned(x) => x.inner.to_owned().inner.lock().unwrap().clone(),
-            Py_Config_Mut::RefMut(x) => x.inner.map_as_mut(|x| x.clone()).expect(DESTROYED_ERR_MSG),
-        }
-    }
-}
-
-// implement_type_conversion_v3!(Config, Py_Config_Mut);
+implement_type_conversion_v3!(Config, Py_Config_Mut);
 
 fn format_config<T: Into<Config>>(cfg: T) -> String {
     let cfg: Config = cfg.into();
@@ -149,9 +130,9 @@ impl Py_Config {
         }
     }
 
-    // pub fn __repr__(&self) -> String {
-    //     format_config(self.inner.inner)
-    // }
+    pub fn __repr__(&self) -> String {
+        format_config(self.inner.get_inner())
+    }
 
     fn __getattr__(this: PyObject, py: Python, attr: &str) -> PyResult<PyObject> {
         let reference = this.call_method0(py, intern!(py, "make_ref"))?;

--- a/src/bindings/config.rs
+++ b/src/bindings/config.rs
@@ -5,7 +5,7 @@ use raft::Config;
 use utils::implement_type_conversion_v3;
 use utils::reference_v3::{RefMutOwner, RustRef};
 
-use utils::errors::{Py_RaftError};
+use utils::errors::Py_RaftError;
 
 use super::readonly_option::Py_ReadOnlyOption;
 

--- a/src/bindings/get_entries_context.rs
+++ b/src/bindings/get_entries_context.rs
@@ -1,11 +1,14 @@
 use pyo3::{intern, prelude::*};
 use raft::GetEntriesContext;
 
-use utils::reference::RustRef;
+use utils::{
+    implement_internal_new,
+    reference_v3::{RefMutOwner, RustRef},
+};
 
 #[pyclass(name = "GetEntriesContext")]
 pub struct Py_GetEntriesContext {
-    pub inner: GetEntriesContext,
+    pub inner: RefMutOwner<GetEntriesContext>,
 }
 
 #[pyclass(name = "GetEntriesContext_Ref")]
@@ -18,7 +21,7 @@ impl Py_GetEntriesContext {
     #[staticmethod]
     pub fn empty(can_async: bool) -> Self {
         Py_GetEntriesContext {
-            inner: GetEntriesContext::empty(can_async),
+            inner: RefMutOwner::new(GetEntriesContext::empty(can_async)),
         }
     }
 
@@ -28,15 +31,13 @@ impl Py_GetEntriesContext {
         }
     }
 
-    pub fn __repr__(&self) -> String {
-        format!("{:?}", self.inner)
-    }
-
     fn __getattr__(this: PyObject, py: Python, attr: &str) -> PyResult<PyObject> {
         let reference = this.call_method0(py, intern!(py, "make_ref"))?;
         reference.getattr(py, attr)
     }
 }
+
+implement_internal_new!(GetEntriesContext, Py_GetEntriesContext);
 
 #[pymethods]
 impl Py_GetEntriesContext_Ref {

--- a/src/utils/lib.rs
+++ b/src/utils/lib.rs
@@ -1,3 +1,4 @@
 pub mod errors;
 pub mod reference;
+pub mod reference_v3;
 pub mod unsafe_cast;

--- a/src/utils/reference_v3.rs
+++ b/src/utils/reference_v3.rs
@@ -6,13 +6,15 @@ use std::sync::{Arc, Mutex, Weak};
 use crate::errors::runtime_error;
 use crate::errors::DESTROYED_ERR_MSG;
 
-impl<T: Clone> RefMutOwner<T> {
+impl<T> RefMutOwner<T> {
     pub fn new(inner: T) -> Self {
         Self {
             inner: Arc::new(Mutex::new(inner)),
         }
     }
+}
 
+impl<T: Clone> RefMutOwner<T> {
     pub fn get_inner(&self) -> T {
         self.inner.lock().unwrap().clone()
     }
@@ -75,6 +77,19 @@ impl<T> RustRef<T> {
     pub fn destroyed_error() -> PyErr {
         runtime_error(DESTROYED_ERR_MSG)
     }
+}
+
+#[macro_export]
+macro_rules! implement_internal_new {
+    ($Typ:ty, $Py_Owner_Typ: ident) => {
+        impl $Py_Owner_Typ {
+            pub fn make_internal_new(inner: $Typ) -> Self {
+                $Py_Owner_Typ {
+                    inner: RefMutOwner::new(inner),
+                }
+            }
+        }
+    };
 }
 
 #[macro_export]

--- a/src/utils/reference_v3.rs
+++ b/src/utils/reference_v3.rs
@@ -6,9 +6,6 @@ use std::sync::{Arc, Mutex, Weak};
 use crate::errors::runtime_error;
 use crate::errors::DESTROYED_ERR_MSG;
 
-unsafe impl<T: Send> Send for RefMutOwner<T> {}
-unsafe impl<T: Sync> Sync for RefMutOwner<T> {}
-
 impl<T> RefMutOwner<T> {
     pub fn new(inner: T) -> Self {
         Self {

--- a/src/utils/reference_v3.rs
+++ b/src/utils/reference_v3.rs
@@ -1,0 +1,129 @@
+// Ref:: https://github.com/huggingface/tokenizers/tree/main/bindings/python
+use pyo3::prelude::*;
+use pyo3::PyErr;
+use std::ptr::NonNull;
+use std::sync::{Arc, Mutex, Weak};
+
+use crate::errors::runtime_error;
+use crate::errors::DESTROYED_ERR_MSG;
+
+unsafe impl<T: Send> Send for RefMutOwner<T> {}
+unsafe impl<T: Sync> Sync for RefMutOwner<T> {}
+
+impl<T> RefMutOwner<T> {
+    pub fn new(inner: T) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(inner)),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct RefMutOwner<T> {
+    pub inner: Arc<Mutex<T>>,
+}
+
+#[derive(Clone)]
+pub struct RefMutContainer<T> {
+    inner: Weak<Mutex<Option<NonNull<RefMutOwner<T>>>>>,
+}
+
+impl<T> RefMutContainer<T> {
+    pub fn new(content: &mut RefMutOwner<T>) -> Self {
+        let arc = Arc::new(Mutex::new(NonNull::new(content)));
+        Self {
+            inner: Arc::downgrade(&arc),
+        }
+    }
+
+    pub fn map<F: FnOnce(&T) -> U, U>(&self, f: F) -> Option<U> {
+        self.inner.upgrade().and_then(|arc| {
+            arc.lock().ok().and_then(|guard| {
+                guard.as_ref().and_then(|owner| {
+                    unsafe { owner.clone().as_ref() }
+                        .inner
+                        .lock()
+                        .ok()
+                        .map(|guard| f(&*guard))
+                })
+            })
+        })
+    }
+
+    pub fn map_mut<F: FnOnce(&mut T) -> U, U>(&mut self, f: F) -> Option<U> {
+        self.inner.upgrade().and_then(|arc| {
+            arc.lock().ok().and_then(|mut guard| {
+                guard.as_mut().and_then(|owner| {
+                    unsafe { owner.clone().as_mut() }
+                        .inner
+                        .lock()
+                        .ok()
+                        .map(|mut guard| f(&mut *guard))
+                })
+            })
+        })
+    }
+}
+
+unsafe impl<T: Send> Send for RefMutContainer<T> {}
+unsafe impl<T: Sync> Sync for RefMutContainer<T> {}
+
+#[derive(Clone)]
+pub struct RustRef<T>(pub RefMutContainer<T>);
+
+impl<T> RustRef<T> {
+    pub fn new(s: &mut RefMutOwner<T>) -> Self {
+        Self(RefMutContainer::new(s))
+    }
+
+    /// Provides a way to access a reference to the underlying data
+    pub fn map_as_ref<F, U>(&self, f: F) -> PyResult<U>
+    where
+        F: FnOnce(&T) -> U,
+    {
+        self.0.map(f).ok_or_else(Self::destroyed_error)
+    }
+
+    /// Provides a way to access a mutable reference to the underlying data
+    pub fn map_as_mut<F, U>(&mut self, f: F) -> PyResult<U>
+    where
+        F: FnOnce(&mut T) -> U,
+    {
+        self.0.map_mut(f).ok_or_else(Self::destroyed_error)
+    }
+
+    pub fn destroyed_error() -> PyErr {
+        runtime_error(DESTROYED_ERR_MSG)
+    }
+}
+
+// #[macro_export]
+// // This macro accepts the raft-rs (Rust) type as the first argument and the Py type as the second argument,
+// // And adds some boilerplate codes implementing the From trait for conversion between the two types.
+// macro_rules! implement_type_conversion_v3 {
+//     ($Typ:ty, $Py_Typ_Mut:ident) => {
+//         use utils::errors::DESTROYED_ERR_MSG;
+
+//         impl From<$Py_Typ_Mut<'_>> for $Typ {
+//             fn from(val: $Py_Typ_Mut<'_>) -> Self {
+//                 match val {
+//                     $Py_Typ_Mut::Owned(x) => x.inner.clone(),
+//                     $Py_Typ_Mut::RefMut(mut x) => {
+//                         x.inner.map_as_mut(|x| x.clone()).expect(DESTROYED_ERR_MSG)
+//                     }
+//                 }
+//             }
+//         }
+
+//         impl From<&mut $Py_Typ_Mut<'_>> for $Typ {
+//             fn from(val: &mut $Py_Typ_Mut<'_>) -> Self {
+//                 match val {
+//                     $Py_Typ_Mut::Owned(x) => x.inner.clone(),
+//                     $Py_Typ_Mut::RefMut(x) => {
+//                         x.inner.map_as_mut(|x| x.clone()).expect(DESTROYED_ERR_MSG)
+//                     }
+//                 }
+//             }
+//         }
+//     };
+// }

--- a/src/utils/reference_v3.rs
+++ b/src/utils/reference_v3.rs
@@ -44,9 +44,6 @@ impl<T> RefMutContainer<T> {
     }
 }
 
-unsafe impl<T: Send> Send for RefMutContainer<T> {}
-unsafe impl<T: Sync> Sync for RefMutContainer<T> {}
-
 #[derive(Clone)]
 pub struct RustRef<T>(pub RefMutContainer<T>);
 


### PR DESCRIPTION
Previous attempt: #34.

Fixes #33, #27, #17.

This PR aims to remove RefMutContainer's all redundancy and make it work correctly.