### PR TITLE
Fix memory leak of `RefMutContainer` when using infinite loop

### DIFF
--- a/src/utils/reference.rs
+++ b/src/utils/reference.rs
@@ -65,7 +65,6 @@ pub struct RefMutContainer<T> {
 impl<T> Drop for RefMutContainer<T> {
     fn drop(&mut self) {
         if let Some(id) = self.id {
-            println!("Object removed: '{}'", id);
             let mut owner_table_ptr = self.owner_table.unwrap();
             let owner_table = unsafe { owner_table_ptr.as_mut() };
             owner_table.remove(&id);


### PR DESCRIPTION
I tested this patch on only just simple test like below example yet,

```py
>>> import rraft
>>> c = rraft.Config()
>>> r1 = c.make_ref()
>>> r2 = c.make_ref()
>>> c = None
>>> r1
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
rraft.DestroyedRefUsedError: Cannot use a destroyed object's reference!
>>> r2
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
rraft.DestroyedRefUsedError: Cannot use a destroyed object's reference!
>>> c = rraft.Config()
>>> r1 = None
Object removed: '1'
>>> r2 = None
Object removed: '2'
>>> c
Config { id: 0, election_tick: 20, heartbeat_tick: 2, applied: 0, max_size_per_msg: 0, max_inflight_msgs: 256, check_quorum: false, pre_vote: false, min_election_tick: 0, max_election_tick: 0, read_only_option: Safe, skip_bcast_commit: false, batch_append: false, priority: 0, max_uncommitted_size: 18446744073709551615, max_committed_size_per_ready: 18446744073709551615 }
>>> r1
>>> r2
```