### PR TITLE
Fix `RefMutContainer` drop bug

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,5 +36,6 @@ jobs:
 
     - name: Build and Test
       run: |
+        cargo update -p syn --precise 1.0.99; cargo update -p proc-macro2 --precise 1.0.43
         make install
         make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,11 +31,10 @@ jobs:
     - name: Set up Rust toolchain
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: nightly
+        toolchain: stable
         override: true
 
     - name: Build and Test
       run: |
-        cargo update -p syn --precise 1.0.99; cargo update -p proc-macro2 --precise 1.0.43
         make install
         make test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["profile-rustflags"]
-
 [package]
 name = "rraft-py"
 version = "0.1.0"
@@ -47,13 +45,3 @@ members = [
 [lib]
 name = "rraft"
 crate-type = ["cdylib"]
-
-[profile.dev]
-rustflags = [
-	"-A", "non-snake-case",
-	"-A", "non-upper-case-globals",
-	"-A", "non-camel-case-types",
-	"-A", "clippy::should-implement-trait",
-	"-A", "clippy::new-without-default",
-	"-A", "clippy::module-inception",
-]

--- a/src/bindings/lib.rs
+++ b/src/bindings/lib.rs
@@ -1,3 +1,9 @@
+#![allow(non_camel_case_types)]
+#![allow(non_upper_case_globals)]
+#![allow(non_snake_case)]
+#![allow(clippy::module_inception)]
+#![allow(clippy::new_without_default)]
+#![allow(clippy::should_implement_trait)]
 pub mod config;
 pub mod get_entries_context;
 pub mod global;

--- a/src/external_bindings/lib.rs
+++ b/src/external_bindings/lib.rs
@@ -1,1 +1,7 @@
+#![allow(non_camel_case_types)]
+#![allow(non_upper_case_globals)]
+#![allow(non_snake_case)]
+#![allow(clippy::module_inception)]
+#![allow(clippy::new_without_default)]
+#![allow(clippy::should_implement_trait)]
 pub mod slog;

--- a/src/mem_storage_bindings/lib.rs
+++ b/src/mem_storage_bindings/lib.rs
@@ -1,3 +1,9 @@
+#![allow(non_camel_case_types)]
+#![allow(non_upper_case_globals)]
+#![allow(non_snake_case)]
+#![allow(clippy::module_inception)]
+#![allow(clippy::new_without_default)]
+#![allow(clippy::should_implement_trait)]
 pub mod mem_storage;
 pub mod mem_storage_core;
 pub mod raft;

--- a/src/py_storage_bindings/lib.rs
+++ b/src/py_storage_bindings/lib.rs
@@ -1,3 +1,9 @@
+#![allow(non_camel_case_types)]
+#![allow(non_upper_case_globals)]
+#![allow(non_snake_case)]
+#![allow(clippy::module_inception)]
+#![allow(clippy::new_without_default)]
+#![allow(clippy::should_implement_trait)]
 pub mod py_storage;
 pub mod raft;
 pub mod raft_log;

--- a/src/raftpb_bindings/lib.rs
+++ b/src/raftpb_bindings/lib.rs
@@ -1,3 +1,9 @@
+#![allow(non_camel_case_types)]
+#![allow(non_upper_case_globals)]
+#![allow(non_snake_case)]
+#![allow(clippy::module_inception)]
+#![allow(clippy::new_without_default)]
+#![allow(clippy::should_implement_trait)]
 pub mod conf_change;
 pub mod conf_change_single;
 pub mod conf_change_transition;

--- a/src/utils/lib.rs
+++ b/src/utils/lib.rs
@@ -1,3 +1,9 @@
+#![allow(non_camel_case_types)]
+#![allow(non_upper_case_globals)]
+#![allow(non_snake_case)]
+#![allow(clippy::module_inception)]
+#![allow(clippy::new_without_default)]
+#![allow(clippy::should_implement_trait)]
 pub mod errors;
 pub mod reference;
 pub mod unsafe_cast;

--- a/src/utils/reference.rs
+++ b/src/utils/reference.rs
@@ -63,10 +63,8 @@ pub struct RefMutContainer<T> {
 
 impl<T> Drop for RefMutContainer<T> {
     fn drop(&mut self) {
-        if let Some(id) = self.id {
-            if let Some(owner_refs_ptr) = self.owner_refs.upgrade() {
-                owner_refs_ptr.lock().unwrap().remove(&id);
-            }
+        if let Some(owner_refs_ptr) = self.owner_refs.upgrade() {
+            owner_refs_ptr.lock().unwrap().remove(&self.id.unwrap());
         }
     }
 }
@@ -76,7 +74,6 @@ impl<T> RefMutContainer<T> {
         let arc = Arc::new(Mutex::new(NonNull::new(&mut content.inner)));
         let mut map = content.refs.lock().unwrap();
         let id = map.keys().max().cloned().unwrap_or(0) + 1;
-
         map.insert(id, Arc::downgrade(&arc));
 
         RefMutContainer {

--- a/src/utils/reference.rs
+++ b/src/utils/reference.rs
@@ -13,7 +13,7 @@ use crate::errors::{DestroyedRefUsedError, DESTROYED_ERR_MSG};
 pub struct RefMutOwner<T> {
     pub inner: T,
     // References that need to be cleaned up.
-    refs: HashMap<u64, Weak<Mutex<Option<NonNull<T>>>>>,
+    refs: Arc<Mutex<HashMap<u64, Weak<Mutex<Option<NonNull<T>>>>>>>,
 }
 
 unsafe impl<T: Send> Send for RefMutOwner<T> {}
@@ -23,7 +23,7 @@ impl<T> RefMutOwner<T> {
     pub fn new(inner: T) -> Self {
         Self {
             inner,
-            refs: HashMap::new(),
+            refs: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 }
@@ -44,7 +44,7 @@ impl<T> DerefMut for RefMutOwner<T> {
 
 impl<T> Drop for RefMutOwner<T> {
     fn drop(&mut self) {
-        self.refs.iter_mut().for_each(|weak_ref| {
+        self.refs.lock().unwrap().iter_mut().for_each(|weak_ref| {
             if let Some(arc) = weak_ref.1.upgrade() {
                 if let Ok(mut ptr) = arc.lock() {
                     ptr.take();
@@ -58,15 +58,15 @@ impl<T> Drop for RefMutOwner<T> {
 pub struct RefMutContainer<T> {
     inner: Arc<Mutex<Option<NonNull<T>>>>,
     id: Option<u64>,
-    owner_table: Option<NonNull<HashMap<u64, Weak<Mutex<Option<NonNull<T>>>>>>>,
+    owner_refs: Weak<Mutex<HashMap<u64, Weak<Mutex<Option<NonNull<T>>>>>>>,
 }
 
 impl<T> Drop for RefMutContainer<T> {
     fn drop(&mut self) {
         if let Some(id) = self.id {
-            let mut owner_table_ptr = self.owner_table.unwrap();
-            let owner_table = unsafe { owner_table_ptr.as_mut() };
-            owner_table.remove(&id);
+            if let Some(owner_refs_ptr) = self.owner_refs.upgrade() {
+                owner_refs_ptr.lock().unwrap().remove(&id);
+            }
         }
     }
 }
@@ -74,13 +74,15 @@ impl<T> Drop for RefMutContainer<T> {
 impl<T> RefMutContainer<T> {
     pub fn new(content: &mut RefMutOwner<T>) -> Self {
         let arc = Arc::new(Mutex::new(NonNull::new(&mut content.inner)));
-        let id = content.refs.keys().max().unwrap_or_else(|| &0) + 1;
-        content.refs.insert(id, Arc::downgrade(&arc));
+        let mut map = content.refs.lock().unwrap();
+        let id = map.keys().max().cloned().unwrap_or(0) + 1;
+
+        map.insert(id, Arc::downgrade(&arc));
 
         RefMutContainer {
             inner: arc,
             id: Some(id),
-            owner_table: NonNull::new(&mut content.refs),
+            owner_refs: Arc::downgrade(&content.refs),
         }
     }
 
@@ -88,7 +90,7 @@ impl<T> RefMutContainer<T> {
         RefMutContainer {
             inner: Arc::new(Mutex::new(NonNull::new(content))),
             id: None,
-            owner_table: None,
+            owner_refs: Weak::new(),
         }
     }
 

--- a/src/utils/reference.rs
+++ b/src/utils/reference.rs
@@ -9,11 +9,13 @@ use std::sync::{Arc, Mutex, Weak};
 
 use crate::errors::{DestroyedRefUsedError, DESTROYED_ERR_MSG};
 
+// References that need to be cleaned up.
+type RefMutContainerTable<T> = HashMap<u64, Weak<Mutex<Option<NonNull<T>>>>>;
+
 #[derive(Clone)]
 pub struct RefMutOwner<T> {
     pub inner: T,
-    // References that need to be cleaned up.
-    refs: Arc<Mutex<HashMap<u64, Weak<Mutex<Option<NonNull<T>>>>>>>,
+    refs: Arc<Mutex<RefMutContainerTable<T>>>,
 }
 
 unsafe impl<T: Send> Send for RefMutOwner<T> {}
@@ -58,7 +60,7 @@ impl<T> Drop for RefMutOwner<T> {
 pub struct RefMutContainer<T> {
     inner: Arc<Mutex<Option<NonNull<T>>>>,
     id: Option<u64>,
-    owner_refs: Weak<Mutex<HashMap<u64, Weak<Mutex<Option<NonNull<T>>>>>>>,
+    owner_refs: Weak<Mutex<RefMutContainerTable<T>>>,
 }
 
 impl<T> Drop for RefMutContainer<T> {


### PR DESCRIPTION
Existing `RefMutContainer` code also causes undefined behavior easily due to using unsafe code wrong.

For example,

```
>>> import rraft
>>> c = rraft.Config()
>>> r = c.make_ref()
>>> c = None
>>> r = None
(REPL spinning, not return)
```

After this patch,

```
>>> import rraft
>>> c = rraft.Config()
>>> r = c.make_ref()
>>> c = None
>>> r
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
rraft.DestroyedRefUsedError: Cannot use a destroyed object's reference!
>>> c = rraft.Config()
>>> r = c.make_ref()
>>> c = None
>>> r = None
>>> c
>>> r
>>> 
```